### PR TITLE
Add default mailhog SMTP port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Now switch back to the `demo` realm, then click on `Realm Settings` then `Email`
 Fill in the following values:
 
 * Host: `demo-mail`
+* Port: `1025`
 * From: `keycloak@localhost`
 
 Click `Save` and `Test connection`. Open your http://localhost:8025 and check that you have


### PR DESCRIPTION
I am opening this PR because your tutorial "Configuring SMTP server" didn't work, I check the [mailhog](https://hub.docker.com/r/mailhog/mailhog/) dockerhub page and see that the default SMTP server is 1025 but Keycloak was using 25 (default), after I change it worked fine.