### PR TITLE
Simplify build and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,27 @@ This project contains a DIY deep dive into Keycloak.
 The steps included here requires Docker (or Podman). It should also be possible to replicate the steps without Docker by
 adapting the steps accordingly.
 
+## Quick setup (docker-compose)
 
-## Start containers
+For an initial setup, a maven build of the custom providers and themes is required first:
+
+    mvn clean install
+
+Once this is done, the demo infrastructure can be built and started with a single command:
+
+    docker-compose up -d
+
+The infrastructure is shut down with
+
+    docker-compose down
+
+Note that all services are ephemeral. Hence, the next 'docker-compose up' will start a
+new, pristine environment.
+
+## Manual setup (docker)
+
+The demo infrastructure can also be set up manually, without resorting to docker-compose, as
+follows.
 
 ### Create a user defined network
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ adapting the steps accordingly.
 
 ## Quick setup (docker-compose)
 
-For an initial setup, a maven build of the custom providers and themes is required first:
-
-    mvn clean install
-
-Once this is done, the demo infrastructure can be built and started with a single command:
+The demo infrastructure can be built and started with a single command:
 
     docker-compose up -d
 
@@ -37,15 +33,11 @@ To make it easy to connect Keycloak to LDAP and the mail server create a user de
 
 We're going to use an extended Keycloak image that includes a custom theme and some custom providers.
 
-First, build the custom providers and themes with:
-
-    mvn clean install
-
-Then build the image with:
+Build the image with:
     
     docker build -t demo-keycloak -f keycloak/Dockerfile .
 
-Finally run it with:
+This will build and include some custom providers and themes as well. Run the image with:
 
     docker run --name demo-keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin \
         -p 8080:8080 --net demo-network demo-keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+---
+version: "3.4"
+
+services:
+  demo-keycloak:
+    build:
+      context: .
+      dockerfile: keycloak/Dockerfile
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+    image: demo-keycloak
+    networks:
+    - demo-network
+    ports:
+    - "8080:8080"
+  demo-ldap:
+    build:
+      context: ldap
+    image: demo-ldap
+    networks:
+    - demo-network
+  demo-mail:
+    image: mailhog/mailhog
+    ports:
+    - "8025:8025"
+    networks:
+    - demo-network
+  demo-js-console:
+    build:
+      context: js-console
+    image: demo-js-console
+    ports:
+    - "8000:80"
+    networks:
+    - demo-network
+
+networks:
+  demo-network: {}

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,10 +1,25 @@
+FROM jboss/keycloak:9.0.2 as builder
+
+USER root
+RUN microdnf update -y && microdnf install -y maven
+
+USER 1000
+
+COPY pom.xml .
+COPY magic-link/ ./magic-link/
+COPY themes/ ./themes/
+COPY token-validation/ ./token-validation/
+
+RUN mvn clean || :
+RUN mvn install
+
 FROM jboss/keycloak:9.0.2
 
-COPY magic-link/target/magic-link.jar /opt/jboss/keycloak/standalone/deployments/
+COPY --from=builder magic-link/target/magic-link.jar /opt/jboss/keycloak/standalone/deployments/
 RUN touch /opt/jboss/keycloak/standalone/deployments/magic-link.jar.dodeploy
 
-COPY themes/target/themes.jar /opt/jboss/keycloak/standalone/deployments/
+COPY --from=builder themes/target/themes.jar /opt/jboss/keycloak/standalone/deployments/
 RUN touch /opt/jboss/keycloak/standalone/deployments/themes.jar.dodeploy
 
-COPY token-validation/target/token-validation.jar /opt/jboss/keycloak/standalone/deployments/
+COPY --from=builder token-validation/target/token-validation.jar /opt/jboss/keycloak/standalone/deployments/
 RUN touch /opt/jboss/keycloak/standalone/deployments/token-validation.jar.dodeploy


### PR DESCRIPTION
Pushed custom theme and providers into the docker build itself, and added a `docker-compose` configuration. This simplifies the setup of the demo environment to a single command.